### PR TITLE
P9 Issue 66 - HR Records & Roster Only access from guard login page (no logbook entry)

### DIFF
--- a/C4iSytemsMobApp/GuardHrRosterMenuPage.xaml
+++ b/C4iSytemsMobApp/GuardHrRosterMenuPage.xaml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="C4iSytemsMobApp.GuardHrRosterMenuPage"
+             BackgroundColor="{AppThemeBinding Light=#f4f2f7, Dark=#1e1e1e}">
+
+    <ScrollView>
+        <VerticalStackLayout Padding="20"
+                             Spacing="20">
+
+            <Label Text="Menu"
+                   FontAttributes="Bold"
+                   FontSize="20"
+                   TextColor="{AppThemeBinding Light=Black, Dark=White}" />
+
+            <Label x:Name="lblGuardName"
+                   FontSize="15"
+                   TextColor="{AppThemeBinding Light=Black, Dark=White}" />
+
+            <Button Text="Notifications"
+                    WidthRequest="250"
+                    HorizontalOptions="Center"
+                    Clicked="OnNotificationsClicked" />
+
+            <Button Text="HR Records"
+                    WidthRequest="250"
+                    HorizontalOptions="Center"
+                    Clicked="OnHrRecordsClicked" />
+
+            <Button Text="Guard Roster"
+                    WidthRequest="250"
+                    HorizontalOptions="Center"
+                    Clicked="OnGuardRosterClicked" />
+
+            <Button Text="Exit"
+                    WidthRequest="250"
+                    HorizontalOptions="Center"
+                    Clicked="OnExitClicked" />
+
+        </VerticalStackLayout>
+    </ScrollView>
+
+</ContentPage>

--- a/C4iSytemsMobApp/GuardHrRosterMenuPage.xaml.cs
+++ b/C4iSytemsMobApp/GuardHrRosterMenuPage.xaml.cs
@@ -1,0 +1,45 @@
+using C4iSytemsMobApp.Interface;
+
+namespace C4iSytemsMobApp;
+
+public partial class GuardHrRosterMenuPage : ContentPage
+{
+    public GuardHrRosterMenuPage()
+    {
+        InitializeComponent();
+        NavigationPage.SetHasNavigationBar(this, false);
+
+        var guardName = Preferences.Get("GuardName", string.Empty);
+        lblGuardName.Text = string.IsNullOrWhiteSpace(guardName) ? string.Empty : $"Welcome, {guardName}";
+        lblGuardName.IsVisible = !string.IsNullOrWhiteSpace(guardName);
+    }
+
+    private async void OnNotificationsClicked(object sender, EventArgs e)
+    {
+        await DisplayAlert("Notification", "New feature coming soon. Stay tuned!", "OK");
+    }
+
+    private void OnHrRecordsClicked(object sender, EventArgs e)
+    {
+        // PIN was already verified before entering this menu
+        Application.Current.MainPage = new HrRecordsPage();
+    }
+
+    private void OnGuardRosterClicked(object sender, EventArgs e)
+    {
+        // RosterPage detects HrRosterOnlyMode and loads the guard's roster across all sites
+        Application.Current.MainPage = new RosterPage();
+    }
+
+    private void OnExitClicked(object sender, EventArgs e)
+    {
+        Preferences.Remove("HrRosterOnlyMode");
+        Preferences.Remove("GuardId");
+        Preferences.Remove("GuardName");
+        Preferences.Remove("LicenseNumber");
+
+        var crowdControlSettingsService = IPlatformApplication.Current.Services.GetService<ICrowdControlServices>();
+        var scannerControlServices = IPlatformApplication.Current.Services.GetService<IScannerControlServices>();
+        Application.Current.MainPage = new GuardLoginPage(crowdControlSettingsService, scannerControlServices);
+    }
+}

--- a/C4iSytemsMobApp/GuardLoginPage.xaml
+++ b/C4iSytemsMobApp/GuardLoginPage.xaml
@@ -236,6 +236,14 @@
                     Clicked="OnEnterLogbookClicked"
                     IsVisible="False" />
 
+            <!-- HR Records & Roster Only Button (Initially Hidden) - no logbook entry created -->
+            <Button x:Name="btnHrRosterOnly"
+                    Text="HR Records &amp; Roster Only"
+                    BackgroundColor="#333333"
+                    TextColor="White"
+                    Clicked="OnHrRosterOnlyClicked"
+                    IsVisible="False" />
+
 
             <!-- HR Status Indicators -->
             <HorizontalStackLayout x:Name="hrStatusLayout"

--- a/C4iSytemsMobApp/GuardLoginPage.xaml.cs
+++ b/C4iSytemsMobApp/GuardLoginPage.xaml.cs
@@ -867,6 +867,7 @@ public partial class GuardLoginPage : ContentPage
                 pickerPosition.IsVisible = true;
                 pickerCallsign.IsVisible = true;
                 btnEnterLogbook.IsVisible = true;
+                btnHrRosterOnly.IsVisible = true;
                 vslCalendarLiveEvents.IsVisible = true;
 
                 ToggleInstructionalTextVisibility();
@@ -903,6 +904,7 @@ public partial class GuardLoginPage : ContentPage
                 pickerPosition.IsVisible = false;
                 pickerCallsign.IsVisible = false;
                 btnEnterLogbook.IsVisible = false;
+                btnHrRosterOnly.IsVisible = false;
                 btnRegister.IsEnabled = true;
                 btnRegister.IsVisible = true;
                 vslCalendarLiveEvents.IsVisible = false;
@@ -915,6 +917,82 @@ public partial class GuardLoginPage : ContentPage
         }
     }
        
+    private async void OnHrRosterOnlyClicked(object sender, EventArgs e)
+    {
+        btnHrRosterOnly.IsEnabled = false;
+        try
+        {
+            if (!int.TryParse(Preferences.Get("GuardId", "0"), out int guardId) || guardId <= 0)
+            {
+                await DisplayAlert("Error", "Guard ID not found. Please validate the License Number first.", "OK");
+                return;
+            }
+
+            if (await VerifyGuardHrPinAsync())
+            {
+                Preferences.Set("HrRosterOnlyMode", "true");
+                Application.Current.MainPage = new GuardHrRosterMenuPage();
+            }
+        }
+        finally
+        {
+            btnHrRosterOnly.IsEnabled = true;
+        }
+    }
+
+    private async Task<bool> VerifyGuardHrPinAsync()
+    {
+        var _guardApiServices = IPlatformApplication.Current.Services.GetService<IGuardApiServices>();
+
+        // 1. Check if PIN is set (AccessPermission = true indicates setup mode)
+        (bool AccessPermission, string message) = await _guardApiServices.CheckIfPINSetForTheGuard();
+
+        if (AccessPermission == true)
+        {
+            // PIN is NOT set - first time setup
+            var setPopup = new SetGuardPinPopup();
+            var setPopupResult = await this.ShowPopupAsync(setPopup);
+
+            if (setPopupResult is string newPin && newPin != "Cancel")
+            {
+                var (isSuccess, saveMessage) = await _guardApiServices.SaveNewPINSetForTheGuard(newPin);
+                if (isSuccess)
+                {
+                    return true;
+                }
+                await DisplayAlert("Error", saveMessage, "OK");
+            }
+            return false;
+        }
+
+        // PIN is already set, validate it using CheckGuardPinPopup
+        var checkPopup = new CheckGuardPinPopup();
+        var checkPopupResult = await this.ShowPopupAsync(checkPopup);
+
+        if (checkPopupResult is string action)
+        {
+            switch (action)
+            {
+                case "OK":
+                    return true;
+                case "ForgotPassword":
+                    bool confirm = await DisplayAlert(
+                        "Reset PIN",
+                        "Are you sure you want to reset your PIN? An email will be sent to your registered email address.",
+                        "Yes", "No");
+                    if (confirm)
+                    {
+                        var (isResetSuccess, resetMessage) = await _guardApiServices.ResetGaurdHrPin("Mobile App - HR & Roster Access");
+                        await DisplayAlert(isResetSuccess ? "Success" : "Error", resetMessage, "OK");
+                    }
+                    break;
+                case "Cancel":
+                    break;
+            }
+        }
+        return false;
+    }
+
     private void SetLedColor(BoxView led, string status)
     {
         switch (status?.Trim().ToLower())
@@ -995,7 +1073,8 @@ public partial class GuardLoginPage : ContentPage
         lblloadinginfo.IsVisible = true;
         try
         {
-
+            // Normal logbook session must never carry the HR/Roster-only mode flag
+            Preferences.Remove("HrRosterOnlyMode");
 
             // Retrieve GuardId securely
             string guardIdString = Preferences.Get("GuardId", "");

--- a/C4iSytemsMobApp/HrRecordsPage.xaml.cs
+++ b/C4iSytemsMobApp/HrRecordsPage.xaml.cs
@@ -246,6 +246,12 @@ public partial class HrRecordsPage : ContentPage
 
     private async void OnHomeClicked(object sender, EventArgs e)
     {
+        if (Preferences.Get("HrRosterOnlyMode", "false") == "true")
+        {
+            Application.Current.MainPage = new GuardHrRosterMenuPage();
+            return;
+        }
+
         var volumeButtonService = IPlatformApplication.Current.Services.GetService<IVolumeButtonService>();
         Application.Current.MainPage = new MainPage(volumeButtonService);
     }

--- a/C4iSytemsMobApp/Interface/IGuardApiServices.cs
+++ b/C4iSytemsMobApp/Interface/IGuardApiServices.cs
@@ -24,6 +24,7 @@ namespace C4iSytemsMobApp.Interface
         // Roster Management
         Task<LinkedSitesResponse?> GetLinkedSitesAsync(int siteId);
         Task<WeeklyRoster?> GetGuardRosterAsync(DateTime startDate, DateTime endDate, int? specificSiteId = null);
+        Task<List<GuardSiteRoster>?> GetGuardRosterAcrossSitesAsync(DateTime startDate);
         Task<(bool isSuccess, string message)> UpdateShiftStatusAsync(RosterStatusUpdateModel model);
     }
 }

--- a/C4iSytemsMobApp/Models/RosterModel.cs
+++ b/C4iSytemsMobApp/Models/RosterModel.cs
@@ -296,4 +296,11 @@ namespace C4iSytemsMobApp.Models
             PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
         }
     }
+
+    public class GuardSiteRoster
+    {
+        public int SiteId { get; set; }
+        public string SiteName { get; set; }
+        public WeeklyRoster Roster { get; set; }
+    }
 }

--- a/C4iSytemsMobApp/RosterPage.xaml.cs
+++ b/C4iSytemsMobApp/RosterPage.xaml.cs
@@ -12,6 +12,7 @@ namespace C4iSytemsMobApp
         private DateTime _currentWeekStart;
         private ObservableCollection<SiteRoster> _siteRosters;
         private HubConnection _hubConnection;
+        private readonly bool _guardOnlyMode = Preferences.Get("HrRosterOnlyMode", "false") == "true";
 
         public ObservableCollection<SiteRoster> SiteRosters
         {
@@ -78,8 +79,14 @@ namespace C4iSytemsMobApp
 
             try
             {
+                if (_guardOnlyMode)
+                {
+                    await LoadGuardOnlyRoster(startDate);
+                    return;
+                }
+
                 int currentSiteId = int.Parse(Preferences.Get("SelectedClientSiteId", "0"));
-                
+
                 var linkedSitesResp = await _guardApiServices.GetLinkedSitesAsync(currentSiteId);
                 List<SiteInfo> sitesToFetch = new List<SiteInfo>();
                 bool isLinkedGroup = false;
@@ -112,21 +119,10 @@ namespace C4iSytemsMobApp
                         if (!isHeaderUpdated)
                         {
                             isHeaderUpdated = true;
-                            WeekRangeLabel.Text = roster.WeekRange;
-                            StatusLabel.Text = roster.Status;
-                            string status = (roster.Status ?? "").ToLower();
-                            if (status.Contains("paid")) StatusLabel.TextColor = Colors.Red;
-                            else if (status.Contains("live")) StatusLabel.TextColor = Colors.Green;
-                            else if (status.Contains("inv")) StatusLabel.TextColor = Colors.Blue;
-                            else StatusLabel.TextColor = Colors.Gray;
+                            UpdateWeekHeader(roster);
                         }
 
-                        foreach (var day in roster.Days)
-                        {
-                            day.PendingCount = day.Shifts?.Count(s => s.StatusCode == 0) ?? 0;
-                            day.AcceptedCount = day.Shifts?.Count(s => s.StatusCode == 1) ?? 0;
-                            day.OpenCount = day.Shifts?.Count(s => s.StatusCode == 2) ?? 0;
-                        }
+                        ComputeDayCounts(roster);
 
                         bool showSiteBar = isLinkedGroup;
                         bool isExpanded = !isLinkedGroup || (isLinkedGroup && sitesToFetch.Count == 1);
@@ -143,20 +139,7 @@ namespace C4iSytemsMobApp
                     }
                 }
 
-                MainThread.BeginInvokeOnMainThread(() =>
-                {
-                    if (hasAnyRosters)
-                    {
-                        SiteRosters = newSiteRosters;
-                        RosterContainer.IsVisible = true;
-                        NoRosterLabel.IsVisible = false;
-                    }
-                    else
-                    {
-                        NoRosterLabel.IsVisible = true;
-                        RosterContainer.IsVisible = false;
-                    }
-                });
+                ApplyRosterResults(newSiteRosters, hasAnyRosters);
             }
             catch (Exception ex)
             {
@@ -166,6 +149,86 @@ namespace C4iSytemsMobApp
             {
                 GlobalLoading.IsRunning = false;
             }
+        }
+
+        // HR Records & Roster Only mode: shows the license-entered guard's own shifts across all sites
+        private async Task LoadGuardOnlyRoster(DateTime startDate)
+        {
+            var guardSiteRosters = await _guardApiServices.GetGuardRosterAcrossSitesAsync(startDate);
+
+            // Preserve the expanded/collapsed state of each site across reloads (week navigation, SignalR refresh)
+            var expandedSiteIds = SiteRosters?.Where(s => s.IsExpanded).Select(s => s.SiteId).ToHashSet() ?? new HashSet<int>();
+
+            var newSiteRosters = new ObservableCollection<SiteRoster>();
+            bool hasAnyRosters = false;
+            bool isHeaderUpdated = false;
+
+            foreach (var guardSiteRoster in guardSiteRosters ?? new List<GuardSiteRoster>())
+            {
+                var roster = guardSiteRoster.Roster;
+                if (roster == null || roster.Days.Count == 0) continue;
+
+                hasAnyRosters = true;
+
+                if (!isHeaderUpdated)
+                {
+                    isHeaderUpdated = true;
+                    UpdateWeekHeader(roster);
+                }
+
+                ComputeDayCounts(roster);
+
+                newSiteRosters.Add(new SiteRoster
+                {
+                    SiteId = guardSiteRoster.SiteId,
+                    SiteName = guardSiteRoster.SiteName,
+                    ShowSiteBar = true,
+                    // Sites start collapsed (tap the site bar to expand); a single site opens directly
+                    IsExpanded = expandedSiteIds.Contains(guardSiteRoster.SiteId) || guardSiteRosters.Count == 1,
+                    Days = new ObservableCollection<RosterDay>(roster.Days)
+                });
+            }
+
+            ApplyRosterResults(newSiteRosters, hasAnyRosters);
+        }
+
+        private void UpdateWeekHeader(WeeklyRoster roster)
+        {
+            WeekRangeLabel.Text = roster.WeekRange;
+            StatusLabel.Text = roster.Status;
+            string status = (roster.Status ?? "").ToLower();
+            if (status.Contains("paid")) StatusLabel.TextColor = Colors.Red;
+            else if (status.Contains("live")) StatusLabel.TextColor = Colors.Green;
+            else if (status.Contains("inv")) StatusLabel.TextColor = Colors.Blue;
+            else StatusLabel.TextColor = Colors.Gray;
+        }
+
+        private static void ComputeDayCounts(WeeklyRoster roster)
+        {
+            foreach (var day in roster.Days)
+            {
+                day.PendingCount = day.Shifts?.Count(s => s.StatusCode == 0) ?? 0;
+                day.AcceptedCount = day.Shifts?.Count(s => s.StatusCode == 1) ?? 0;
+                day.OpenCount = day.Shifts?.Count(s => s.StatusCode == 2) ?? 0;
+            }
+        }
+
+        private void ApplyRosterResults(ObservableCollection<SiteRoster> newSiteRosters, bool hasAnyRosters)
+        {
+            MainThread.BeginInvokeOnMainThread(() =>
+            {
+                if (hasAnyRosters)
+                {
+                    SiteRosters = newSiteRosters;
+                    RosterContainer.IsVisible = true;
+                    NoRosterLabel.IsVisible = false;
+                }
+                else
+                {
+                    NoRosterLabel.IsVisible = true;
+                    RosterContainer.IsVisible = false;
+                }
+            });
         }
 
         private DateTime GetStartOfWeek(DateTime dt)
@@ -230,6 +293,12 @@ namespace C4iSytemsMobApp
 
         private void OnHomeClicked(object sender, EventArgs e)
         {
+            if (_guardOnlyMode)
+            {
+                Application.Current.MainPage = new GuardHrRosterMenuPage();
+                return;
+            }
+
             var volumeService = IPlatformApplication.Current.Services.GetService<IVolumeButtonService>();
             Application.Current.MainPage = new MainPage(volumeService);
         }

--- a/C4iSytemsMobApp/Services/GuardApiServices.cs
+++ b/C4iSytemsMobApp/Services/GuardApiServices.cs
@@ -103,6 +103,7 @@ namespace C4iSytemsMobApp.Services
 
         public async Task<(bool isSuccess, string errorMessage)> ValidateGuardDocumentAccessPin(string pin)
         {
+            GetSecureStorageValues();
             string apiUrl = $"{AppConfig.ApiBaseUrl}GuardSecurityNumber/ValidateGuardPinForHrRecordAccess?guardId={guardId}&key={pin}";
             HttpClient client = new HttpClient();
             client.BaseAddress = new Uri(AppConfig.ApiBaseUrl);
@@ -281,6 +282,7 @@ namespace C4iSytemsMobApp.Services
         }
         public async Task<(bool AccessPermission, string message)> CheckIfPINSetForTheGuard()
         {
+            GetSecureStorageValues();
             string apiUrl = $"{AppConfig.ApiBaseUrl}GuardSecurityNumber/CheckIfPINSetForTheGuard?guardId={guardId}";
             HttpClient client = new HttpClient();
             client.BaseAddress = new Uri(AppConfig.ApiBaseUrl);
@@ -303,6 +305,7 @@ namespace C4iSytemsMobApp.Services
 
         public async Task<(bool isSuccess, string message)> SaveNewPINSetForTheGuard(string newPin)
         {
+            GetSecureStorageValues();
             var apiUrl = $"{AppConfig.ApiBaseUrl}GuardSecurityNumber/SaveNewPINSetForTheGuard";
             using var _httpClient = new HttpClient();
             var payload = new { guardId = guardId, newPin = newPin };
@@ -328,6 +331,7 @@ namespace C4iSytemsMobApp.Services
 
         public async Task<(bool isSuccess, string message)> ResetGaurdHrPin(string siteName)
         {
+            GetSecureStorageValues();
             var apiUrl = $"{AppConfig.ApiBaseUrl}GuardSecurityNumber/ResetGaurdHrPin";
             using var _httpClient = new HttpClient();
             var payload = new { guardId = guardId, siteName = siteName };
@@ -402,6 +406,67 @@ namespace C4iSytemsMobApp.Services
                 using var doc = JsonDocument.Parse(json);
                 var root = doc.RootElement;
 
+                return ParseWeeklyRoster(root);
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Exception in GetGuardRosterAsync: {ex.Message}");
+                return new WeeklyRoster { WeekRange = "Error occurred" };
+            }
+        }
+
+        public async Task<List<GuardSiteRoster>?> GetGuardRosterAcrossSitesAsync(DateTime startDate)
+        {
+            try
+            {
+                GetSecureStorageValues();
+
+                if (guardId <= 0)
+                {
+                    return null;
+                }
+
+                string dateParam = startDate.ToString("yyyy-MM-dd");
+                string apiUrl = $"{AppConfig.ApiBaseUrl}GuardSecurityNumber/GetGuardRosterAcrossSites?guardId={guardId}&date={dateParam}";
+
+                using HttpClient client = new HttpClient();
+                client.BaseAddress = new Uri(AppConfig.ApiBaseUrl);
+
+                HttpResponseMessage response = await client.GetAsync(apiUrl);
+                if (!response.IsSuccessStatusCode)
+                {
+                    return null;
+                }
+
+                var json = await response.Content.ReadAsStringAsync();
+                using var doc = JsonDocument.Parse(json);
+                var root = doc.RootElement;
+
+                var siteRosters = new List<GuardSiteRoster>();
+                if (root.TryGetProperty("sites", out var sitesArray))
+                {
+                    foreach (var siteElement in sitesArray.EnumerateArray())
+                    {
+                        siteRosters.Add(new GuardSiteRoster
+                        {
+                            SiteId = siteElement.GetProperty("siteId").GetInt32(),
+                            SiteName = siteElement.GetProperty("siteName").GetString(),
+                            Roster = ParseWeeklyRoster(siteElement)
+                        });
+                    }
+                }
+
+                return siteRosters;
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Exception in GetGuardRosterAcrossSitesAsync: {ex.Message}");
+                return null;
+            }
+        }
+
+        private WeeklyRoster ParseWeeklyRoster(JsonElement root)
+        {
                 var result = new WeeklyRoster
                 {
                     StartDate = DateTime.Parse(root.GetProperty("startDate").GetString()),
@@ -502,12 +567,6 @@ namespace C4iSytemsMobApp.Services
                 }
 
                 return result;
-            }
-            catch (Exception ex)
-            {
-                Console.WriteLine($"Exception in GetGuardRosterAsync: {ex.Message}");
-                return new WeeklyRoster { WeekRange = "Error occurred" };
-            }
         }
 
         public async Task<(bool isSuccess, string message)> UpdateShiftStatusAsync(RosterStatusUpdateModel model)


### PR DESCRIPTION
## Summary
- New **'HR Records & Roster Only'** button on the guard login page, shown only after a successful license-number lookup (hidden again on 'Go Back'). Lets guards check their HR records and roster **without creating a false 'Logbook Logged In' entry** and without selecting a site.
- **PIN verification is mandatory**: reuses the existing HR PIN flow (first-time set-PIN popup, check-PIN popup, Forgot-PIN reset email) before entering.
- New **GuardHrRosterMenuPage** (Notifications / HR Records / Guard Roster / Exit) styled like the drawer menu. Exit clears the guard session and returns to the login page.
- **HR Records**: reuses `HrRecordsPage` with full view/upload/edit/delete; Home returns to the new menu in this mode.

## Guard Roster - two modes, old behaviour untouched
**The existing roster page is NOT changed to guard-specific.** `RosterPage` now has two modes:

| | Old mode (normal site login, drawer > Guard Roster) | New guard-only mode (HR Records & Roster Only) |
|---|---|---|
| Trigger | Guard logs into the logbook via 'Access C4i System' | New button on login page after license + PIN |
| Scope | **Logged-in site only** (plus duress-linked site group), exactly as before | The **license-entered guard's own shifts across ALL sites** |
| Shifts shown | **All guards** rostered at that site (old logic, unchanged) | **Only that guard's** shifts (as guard or relief guard) |
| API | Existing `GetRoster?siteId=` (untouched) | New `GetGuardRosterAcrossSites?guardId=` (CityWatch web PR #1767) |
| Site bars | Linked-site group behaviour as before | Every site shown as a collapsed site-name bar; tap to expand (reuses the existing accordion) |
| Home button | Returns to MainPage as before | Returns to the new menu page |

The mode is driven by the `HrRosterOnlyMode` preference, which is set only by the new button and is always cleared on a normal logbook login - so the old site-specific roster can never accidentally switch to guard view.

In **both** modes all roster facilities work identically: accept, decline/reject with reason, re-accept, relief pickup, week navigation, expand/collapse-all, and two-way SignalR live sync with the web roster. In guard-only mode, expanded sites stay open across live refreshes.

- Fix: PIN service methods now refresh `GuardId` from Preferences at call time (the singleton previously kept the value captured at first resolve).

## No impact on existing flows
- Normal 'Access C4i System' login clears the mode flag, so the drawer Roster stays site-scoped (linked-site behaviour untouched) and HR Records Home still returns to MainPage.
- Site-roster load path is logic-identical (extract-method only); `MainPage` untouched.

## Testing
- License lookup shows both buttons; Go Back hides them; new button gates via PIN; no logbook row created.
- Menu: HR records CRUD, guard-only roster across sites with accept/decline + live web sync, Exit returns to login with prefs cleared.
- Regression: normal login -> drawer Roster shows the full site roster (all guards, linked sites) exactly as before; HR Records behaves as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)